### PR TITLE
make the test order-agnostic

### DIFF
--- a/src/comprehension.nim
+++ b/src/comprehension.nim
@@ -1,4 +1,4 @@
-import macros, tables, sets, typetraits, sequtils
+import macros, tables, sets, typetraits
 
 
 proc compImpl(f: NimNode, isSet: static[bool]): NimNode =

--- a/tests/test_comprehension.nim
+++ b/tests/test_comprehension.nim
@@ -1,4 +1,4 @@
-import unittest, comprehension, tables, sets, sequtils
+import unittest, comprehension, tables, sets
 
 {.experimental: "forLoopMacros".}
 
@@ -15,5 +15,5 @@ suite "comprehension":
 
   test "seq from table":
     let g = comp[for k, v in a: k + v]
-    check(g == @[0, 3])
+    check(g in @[@[0, 3], @[3, 0]])
 


### PR DESCRIPTION
This allows it to be not dependent on the current `tables` implementation.

(Discovered in https://github.com/nim-lang/Nim/pull/14926, which slightly changes the implementation)